### PR TITLE
The failed message reports the ip of my graylog2 server instead of the no

### DIFF
--- a/lib/chef/gelf.rb
+++ b/lib/chef/gelf.rb
@@ -23,7 +23,7 @@ class Chef
         Chef::Log.debug "Reporting #{run_status.inspect}"
         if run_status.failed?
           Chef::Log.debug "Notifying Graylog server of failure."
-          @notifier.notify!(:short_message => "Chef run failed on #{@notifier.host}. Updated #{changes[:count]} resources.",
+          @notifier.notify!(:short_message => "Chef run failed on #{node.name}. Updated #{changes[:count]} resources.",
                             :full_message => run_status.formatted_exception + "\n" + Array(backtrace).join("\n") + changes[:message],
                             :level => ::GELF::Levels::FATAL,
                             :host => host_name)


### PR DESCRIPTION
The failed message reports the ip of my graylog2 server instead of the node name.
