### PR TITLE
gelf: Fix sanitised_changes method

### DIFF
--- a/lib/chef/gelf.rb
+++ b/lib/chef/gelf.rb
@@ -61,13 +61,13 @@ class Chef
 
       def sanitised_changes
         run_status.updated_resources.reject do |updated|
-          options[:blacklist].each do |cookbook, resources|
-            resources.each do |resource, actions|
-              updated.cookbook_name == cookbook && 
-              updated.resource_name == resource && 
-              actions.collect { |a| a.to_s }.include?(updated.action.to_s)
-            end
+          cookbook = @options[:blacklist][updated.cookbook_name]
+          if cookbook
+            resource = cookbook[updated.resource_name.to_s] || []
+          else
+            resource = []
           end
+          cookbook && resource.include?(updated.action.to_s)
         end
       end
     end


### PR DESCRIPTION
The current method (having an #each inside #reject) was causing it to always
reject everything since #each returns the original object. This was the
simplest way I could come up with while keeping the original
functionality. It's probably wrong but hopefully it helps someone do it right.

This is the behavior I'm seeing on 1.8.7p249 (Ubuntu) and 1.9.3 (OSX):

``` ruby
[1,2,3].reject { |a| {}.each { |k,v| true } }
=> []
[1,2,3].reject { |a| {}.each { |k,v| false } }
=> []
[1,2,3].reject { |a| {} }
=> []
[1,2,3].reject { |a| true }
=> []
[1,2,3].reject { |a| false }
=> [1, 2, 3]
```
